### PR TITLE
add header creation methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,18 @@ extern crate failure;
 mod header;
 
 pub use header::*;
+
+/// Create a new `Header` in the `Bitfield` configuration.
+pub fn create_bitfield() -> Header {
+  Header::new(FileType::BitField, 3328, HashType::None)
+}
+
+/// Create a new `Header` in the `Signatures` configuration.
+pub fn create_signatures() -> Header {
+  Header::new(FileType::Signatures, 64, HashType::Ed25519)
+}
+
+/// Create a new `Header` in the `Tree` configuration.
+pub fn create_tree() -> Header {
+  Header::new(FileType::Tree, 40, HashType::BLAKE2b)
+}

--- a/tests/fns.rs
+++ b/tests/fns.rs
@@ -1,0 +1,18 @@
+extern crate sleep_parser;
+
+use sleep_parser::*;
+
+#[test]
+fn bitfield() {
+  assert!(create_bitfield().is_bitfield());
+}
+
+#[test]
+fn signatures() {
+  assert!(create_signatures().is_signatures());
+}
+
+#[test]
+fn tree() {
+  assert!(create_tree().is_tree());
+}

--- a/tests/header.rs
+++ b/tests/header.rs
@@ -1,6 +1,6 @@
 extern crate sleep_parser;
 
-use sleep_parser::{FileType, HashType, Header};
+use sleep_parser::*;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 


### PR DESCRIPTION
Provides three shorthand methods to create headers in a particular configuration. Easier than declaring this code inline in projects. Thanks!