### PR TITLE
Add fuzzer

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,22 @@
+
+[package]
+name = "sleep-parser-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies.sleep-parser]
+path = ".."
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "header-from-vec"
+path = "fuzz_targets/header-from-vec.rs"

--- a/fuzz/fuzz_targets/header-from-vec.rs
+++ b/fuzz/fuzz_targets/header-from-vec.rs
@@ -1,0 +1,9 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate sleep_parser;
+
+fuzz_target!(|data: &[u8]| {
+  if let Ok(header) = sleep_parser::Header::from_vec(data) {
+    sleep_parser::Header::from_vec(&header.to_vec()).unwrap();
+  }
+});


### PR DESCRIPTION
After `cargo install cargo-fuzz`, you can run this with

    cargo fuzz run header-from-vec

In contrast to https://github.com/rust-fuzz/targets/pull/114 this only uses libfuzzer for now.

cc #3